### PR TITLE
Make label-warning more easily distinguishable from label-danger

### DIFF
--- a/ofcourse/static/css/site.css
+++ b/ofcourse/static/css/site.css
@@ -106,3 +106,7 @@ h1,h2,h3,h4,h5,h6, .jumbotron p {
 .vaycay {
     background: darkgrey;
 }
+
+.label-warning {
+  background: #ffc722;
+}


### PR DESCRIPTION
![sample](https://cloud.githubusercontent.com/assets/636610/6922098/cf48dc16-d796-11e4-9d2d-8f9041292c0c.png)

Resolves #43 