### PR TITLE
Issue #51 fix attempt #2

### DIFF
--- a/ofcourse/static/css/site.css
+++ b/ofcourse/static/css/site.css
@@ -12,6 +12,14 @@ body {
     padding-bottom: 40px;
 }
 
+.alert {
+    color: #333;
+}
+
+div.alert.alert-info, div.alert.alert-success, div.alert.alert-warning, div.alert.alert-failure {
+    color: #FFF;
+}
+
 a, .alert code>a {
     color: #303f9f;
 }

--- a/ofcourse/static/css/site.css
+++ b/ofcourse/static/css/site.css
@@ -12,7 +12,7 @@ body {
     padding-bottom: 40px;
 }
 
-a {
+a, .alert code>a {
     color: #303f9f;
 }
 


### PR DESCRIPTION
These two commits are intended to fix ryansb/ofCourse#51.  Using white text on a white/light background makes nothing readable; these patches to the site.css file should make things more legible going forward (hopefully).

Also, @liam-middlebrook & others - I've tested this change on my personal machine.  Learned that lesson.