### PR TITLE
MarkDown/RST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,12 +60,10 @@ docs/_build/
 # PyBuilder
 target/
 
-# Tox
-AUTHORS
-ChangeLog
-
 # PBR
 .eggs/
+AUTHORS
+ChangeLog
 
 # Virtualenvwrapper/VirtualFish
 .venv

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,13 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Tox
+AUTHORS
+ChangeLog
+
+# PBR
+.eggs/
+
+# Virtualenvwrapper/VirtualFish
+.venv

--- a/ofcourse-templates/hw/index.html
+++ b/ofcourse-templates/hw/index.html
@@ -9,7 +9,7 @@
     <div class="span4">
         <ul class="list-unstyled">
             <li><h2>Tasks</h2></li>
-            {% for hw, loc in hws|dictsort %}
+            {% for hw, loc in assignments|dictsort %}
               <li><a href="{{loc}}">{{hw}}</a></li>
             {% endfor %}
         </ul>

--- a/ofcourse-templates/syllabus.html
+++ b/ofcourse-templates/syllabus.html
@@ -349,10 +349,9 @@
   <p>Assignments are due at 4:59pm of the day they are marked as due, to be useful in class.</p>
   <p>Late submissions will be deducted <span class="label label-danger">10%</span> per day they are late.</p>
   <hr class="docutils" />
-  <p>Your final grade for the quarter will be derived from the following weights.</p>
+  <p>Your final grade for the semester will be derived from the following weights.</p>
 
-  <table class="table table-striped table-bordered"
-   class="docutils">
+  <table class="table table-striped table-bordered docutils">
     <colgroup>
       <col style="width: 80%;" />
       <col style="width: 20%;" />

--- a/ofcourse/render.py
+++ b/ofcourse/render.py
@@ -93,7 +93,8 @@ def render_init(app):
     '''
     Set up all renderers and filters for a provided class
     '''
-    _renderers[:] = []
+    global renderers
+    _renderers = []
     for cls in _renderer_classes:
         _renderers.append(cls(app))
     for name, filt in _filters:

--- a/ofcourse/render.py
+++ b/ofcourse/render.py
@@ -52,7 +52,7 @@ try:
     _renderer_classes.append(make_renderer(
         mako.render_template, ".mak", TopLevelLookupException,
         init=mako.MakoTemplates,
-        params={'name', 'mako'},
+        params={'name': 'mako'},
         config={'MAKO_TRANSLATE_EXCEPTIONS': False}))
 except ImportError:
     # Mako extensions don't exist

--- a/ofcourse/render.py
+++ b/ofcourse/render.py
@@ -15,7 +15,8 @@ import flask
 
 # Renderers {{{
 # Renderer template {{{
-def make_renderer(render, suffixes, exception, init=None, config={}, params={}):
+def make_renderer(render, suffixes, exception,
+                  init=None, config={}, params={}):
     class Renderer(object):
         def __init__(self, app):
             ''' Perform required setup '''

--- a/ofcourse/render.py
+++ b/ofcourse/render.py
@@ -1,5 +1,6 @@
 """
-Author: Remy D <remyd@civx.us>
+Author: Matt Soucy <msoucy@csh.rit.edu>
+        Remy D <remyd@civx.us>
         Ralph Bean <rbean@redhat.com>
         Sam Lucidi <mansam@csh.rit.edu>
 License: Apache 2.0
@@ -14,7 +15,7 @@ import flask
 
 # Renderers {{{
 # Renderer template {{{
-def make_renderer(render, suffix, exception, init=None, config={}, params={}):
+def make_renderer(render, suffixes, exception, init=None, config={}, params={}):
     class Renderer(object):
         def __init__(self, app):
             ''' Perform required setup '''
@@ -24,12 +25,13 @@ def make_renderer(render, suffix, exception, init=None, config={}, params={}):
 
         def __call__(self, template, **kwargs_raw):
             ''' Attempt to render '''
-            try:
-                kwargs = kwargs_raw.copy()
-                kwargs.update(params)
-                return render(template + suffix, **kwargs)
-            except exception:
-                pass
+            kwargs = kwargs_raw.copy()
+            kwargs.update(params)
+            for suffix in suffixes:
+                try:
+                    return render(template + suffix, **kwargs)
+                except exception:
+                    pass
     return Renderer
 # }}}
 
@@ -39,7 +41,7 @@ _renderer_classes = []
 try:
     import jinja2
     _renderer_classes.append(make_renderer(
-        flask.render_template, ".html", jinja2.TemplateNotFound))
+        flask.render_template, (".html", ".htm"), jinja2.TemplateNotFound))
 except ImportError:
     # Somehow, jinja isn't supported
     pass
@@ -50,7 +52,7 @@ try:
     import flask.ext.mako as mako
     from mako.exceptions import TopLevelLookupException
     _renderer_classes.append(make_renderer(
-        mako.render_template, ".mak", TopLevelLookupException,
+        mako.render_template, (".mak", ".mako"), TopLevelLookupException,
         init=mako.MakoTemplates,
         params={'name': 'mako'},
         config={'MAKO_TRANSLATE_EXCEPTIONS': False}))

--- a/ofcourse/render.py
+++ b/ofcourse/render.py
@@ -6,22 +6,95 @@ License: Apache 2.0
 
 """
 
-import os
+from functools import partial
 
 # flask dependencies
 import flask
-import flask.ext.mako as mako
-from jinja2 import TemplateNotFound
-from mako.exceptions import TopLevelLookupException
 
-# ofcourse dependencies
-from .util import app_path
+
+# Renderers {{{
+# Renderer template {{{
+def make_renderer(render, suffix, exception, init=None, config={}, params={}):
+    class Renderer(object):
+        def __init__(self, app):
+            ''' Perform required setup '''
+            if init:
+                init(app)
+            app.config.update(config)
+
+        def __call__(self, template, **kwargs_raw):
+            ''' Attempt to render '''
+            try:
+                kwargs = kwargs_raw.copy()
+                kwargs.update(params)
+                return render(template + suffix, **kwargs)
+            except exception:
+                pass
+    return Renderer
+# }}}
+
+_renderer_classes = []
+
+# Jinja2 files (.html) {{{
+try:
+    import jinja2
+    _renderer_classes.append(make_renderer(
+        flask.render_template, ".html", jinja2.TemplateNotFound))
+except ImportError:
+    # Somehow, jinja isn't supported
+    pass
+# }}}
+
+# Mako files (.mak) {{{
+try:
+    import flask.ext.mako as mako
+    from mako.exceptions import TopLevelLookupException
+    _renderer_classes.append(make_renderer(
+        mako.render_template, ".mak", TopLevelLookupException,
+        init=mako.MakoTemplates,
+        params={'name', 'mako'},
+        config={'MAKO_TRANSLATE_EXCEPTIONS': False}))
+except ImportError:
+    # Mako extensions don't exist
+    pass
+# }}}
+# }}}
+
+# Filters {{{
+_filters = []
+
+# Markdown {{{
+try:
+    import markdown
+    _filters.append(
+        ("markdown", partial(markdown.markdown, extensions=("extra",))))
+except:
+    pass
+# }}}
+
+# reStructuredText {{{
+try:
+    from docutils.core import publish_parts
+    _filters.append((
+        "rst",
+        lambda txt: publish_parts(txt, writer_name='html')['fragment']))
+except:
+    pass
+# }}}
+# }}}
+
+_renderers = []
 
 
 def render_init(app):
-    ' Wrap initialization for Mako templates '
-    mako.MakoTemplates(app)
-    app.config['MAKO_TRANSLATE_EXCEPTIONS'] = False
+    '''
+    Set up all renderers and filters for a provided class
+    '''
+    _renderers[:] = []
+    for cls in _renderer_classes:
+        _renderers.append(cls(app))
+    for name, filt in _filters:
+        app.jinja_env.filters[name] = filt
 
 
 def render_template(template, **kwargs_raw):
@@ -30,15 +103,9 @@ def render_template(template, **kwargs_raw):
 
     Default to Jinja2 templates, fallback to mako
     '''
-    templates = [
-        (flask.render_template, ".html", {}, TemplateNotFound),
-        (mako.render_template, ".mak",
-            {'name': 'mako'}, TopLevelLookupException),
-    ]
-    for render, suff, keys, ex in templates:
-        try:
-            kwargs = kwargs_raw.copy()
-            kwargs.update(keys)
-            return render(template + suff, **kwargs)
-        except ex:
-            pass
+    for render in _renderers:
+        ret = render(template, **kwargs_raw)
+        if ret is not None:
+            return ret
+
+# vim: fdm=marker:et:ts=4:sw=4

--- a/ofcourse/site.py
+++ b/ofcourse/site.py
@@ -47,7 +47,6 @@ def inject_yaml():
         site_config['course']['public_url'] = course_url
     return site_config
 
-app.config['MAKO_TRANSLATE_EXCEPTIONS'] = False
 config = inject_yaml()
 COURSE_START = datetime.combine(config['course']['start'], datetime.min.time())
 COURSE_END = datetime.combine(config['course']['end'], datetime.max.time())


### PR DESCRIPTION
Allows usage of

```jinja
{% filter markdown %}
This is *formatted* with **Markdown**
{% endfilter %}
```

As well as `filter rst` - only if the Markdown and docutils libs are available, respectively