### PR TITLE
Update Wordpress-specific instructions

### DIFF
--- a/ofcourse-templates/hw/firstflight.html
+++ b/ofcourse-templates/hw/firstflight.html
@@ -151,7 +151,7 @@ you are supposed to have more than 10 blog posts. In order to fix this issue
 you must take the following steps.
   <ol>
       <li>
-      Log in to your Wordpress Administration Site
+      Log in to your Wordpress Administration Site at https://WORDPRESS_BLOG_NAME.wordpress.com/wp-admin/options-reading.php
       </li>
       <li>
       Go to Settings


### PR DESCRIPTION
Just for clarity's sake, there's a settings page on Wordpress's website at https://wordpress.com/settings/general/WORDPRESS_BLOG_NAME and another settings page on your blog's subdomain at https://WORDPRESS_BLOG_NAME.wordpress.com/wp-admin/options-reading.php

Took me a few minutes of digging and looking at guides to realize the settings page on Wordpress's site is not the one with the "reading" settings page I was searching for. Figured for clarity's sake, I felt it would be useful to add an example link so future bloggers don't run into this problem