### PR TITLE
Increased link color specificity in site.css

### DIFF
--- a/ofcourse/static/css/site.css
+++ b/ofcourse/static/css/site.css
@@ -20,7 +20,7 @@ div.alert.alert-info, div.alert.alert-success, div.alert.alert-warning, div.aler
     color: #FFF;
 }
 
-a, .alert code>a {
+a, .alert code>a, .alert a {
     color: #303f9f;
 }
 


### PR DESCRIPTION
Fix for [Link color being indifferent from base text color](https://github.com/ryansb/ofCourse/issues/66)

material-wfont.min.css had a higher priority for link colors over site.css, overriding the "correct" link color in site.css making links appear to be the same color as non-link text.

This change increases the specificity of link colors in site.css to change the color of links, thereby making it more clear on the page which lines of text are links.